### PR TITLE
drivers: wifi: Disable debugs by default

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -422,7 +422,6 @@ config NRF_WIFI_RPU_MIN_TIME_TO_ENTER_SLEEP_MS
 
 config NRF_WIFI_RPU_RECOVERY_DEBUG
 	bool "Enable RPU recovery debug logs"
-	default y
 	help
 		Enable RPU recovery debug logs to help debug RPU recovery mechanism.
 


### PR DESCRIPTION
Now that the feature is stabilised, disable debugs by default.